### PR TITLE
🩹 [Patch]: Bump `Admin` and add `Scope` as private enum

### DIFF
--- a/src/classes/private/Scope.ps1
+++ b/src/classes/private/Scope.ps1
@@ -1,0 +1,4 @@
+﻿enum Scope {
+    CurrentUser
+    AllUsers
+}

--- a/src/functions/public/Get-Font.ps1
+++ b/src/functions/public/Get-Font.ps1
@@ -44,10 +44,7 @@ function Get-Font {
         [string[]] $Name = '*',
 
         # Specifies the scope of the font(s) to get.
-        [Parameter(
-            ValueFromPipeline,
-            ValueFromPipelineByPropertyName
-        )]
+        [Parameter(ValueFromPipelineByPropertyName)]
         [Scope[]] $Scope = 'CurrentUser'
     )
 

--- a/src/functions/public/Get-Font.ps1
+++ b/src/functions/public/Get-Font.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Admin'; RequiredVersion = '1.1.2' }
+﻿#Requires -Modules @{ ModuleName = 'Admin'; RequiredVersion = '1.1.3' }
 
 function Get-Font {
     <#

--- a/src/functions/public/Install-Font.ps1
+++ b/src/functions/public/Install-Font.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Admin'; RequiredVersion = '1.1.2' }
+﻿#Requires -Modules @{ ModuleName = 'Admin'; RequiredVersion = '1.1.3' }
 
 function Install-Font {
     <#
@@ -69,10 +69,7 @@ function Install-Font {
         # Scope of the font installation.
         # CurrentUser will install the font for the current user only.
         # AllUsers will install the font so it is available for all users on the system.
-        [Parameter(
-            ValueFromPipeline,
-            ValueFromPipelineByPropertyName
-        )]
+        [Parameter(ValueFromPipelineByPropertyName)]
         [Scope[]] $Scope = 'CurrentUser',
 
         # Recurse will install all fonts in the specified folder and subfolders.
@@ -208,7 +205,7 @@ Please run the command again with elevated rights (Run as Administrator) or prov
     end {
         if ($IsLinux) {
             if ($Verbose) {
-                Write-Verbose "Refreshing font cache"
+                Write-Verbose 'Refreshing font cache'
                 fc-cache -fv
             } else {
                 fc-cache -f

--- a/src/functions/public/Uninstall-Font.ps1
+++ b/src/functions/public/Uninstall-Font.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Admin'; RequiredVersion = '1.1.2' }
+﻿#Requires -Modules @{ ModuleName = 'Admin'; RequiredVersion = '1.1.3' }
 
 function Uninstall-Font {
     <#
@@ -24,15 +24,6 @@ function Uninstall-Font {
     [Alias('Uninstall-Fonts')]
     [CmdletBinding()]
     param (
-        # Scope of the font to uninstall.
-        # CurrentUser will uninstall the font for the current user.
-        # AllUsers will uninstall the font so it is removed for all users.
-        [Parameter(
-            ValueFromPipeline,
-            ValueFromPipelineByPropertyName
-        )]
-        [Scope[]] $Scope = 'CurrentUser',
-
         # Name of the font to uninstall.
         [Parameter(
             Mandatory,
@@ -40,7 +31,13 @@ function Uninstall-Font {
             ValueFromPipelineByPropertyName
         )]
         [SupportsWildcards()]
-        [string[]] $Name
+        [string[]] $Name,
+
+        # Scope of the font to uninstall.
+        # CurrentUser will uninstall the font for the current user.
+        # AllUsers will uninstall the font so it is removed for all users.
+        [Parameter(ValueFromPipelineByPropertyName)]
+        [Scope[]] $Scope = 'CurrentUser'
     )
 
     begin {
@@ -59,8 +56,6 @@ Please run the command again with elevated rights (Run as Administrator) or prov
     }
 
     process {
-        $Name = $PSBoundParameters['Name']
-
         $scopeCount = $Scope.Count
         Write-Verbose "[$functionName] - Processing [$scopeCount] scopes(s)"
         foreach ($scopeItem in $Scope) {

--- a/src/header.ps1
+++ b/src/header.ps1
@@ -1,1 +1,0 @@
-﻿using module @{ ModuleName = 'Admin'; RequiredVersion = '1.1.2' }


### PR DESCRIPTION
## Description

This pull request includes several changes to improve the font management scripts by updating module versions, modifying parameter attributes, and adding an enumeration for scope. The most important changes include updating required module versions, adding a new `Scope` enum, and modifying parameter attributes for better pipeline support.

### Module Version Updates:
* [`src/functions/public/Get-Font.ps1`](diffhunk://#diff-ee20084ba781ca437e01d19ac7f613301852186eaaac3f2a2c56227290631228L1-R1): Updated required version of the `Admin` module from '1.1.2' to '1.1.3'.
* [`src/functions/public/Install-Font.ps1`](diffhunk://#diff-d3add77d9955c82ca6cb9e9614242dfd502f6692662994dcb98d6a58b923abbfL1-R1): Updated required version of the `Admin` module from '1.1.2' to '1.1.3'.
* [`src/functions/public/Uninstall-Font.ps1`](diffhunk://#diff-2bda15615bb104b972c42d08b28af0a1692cbb5ec229ae212fc5959feab71f49L1-R1): Updated required version of the `Admin` module from '1.1.2' to '1.1.3'.

### Enum Addition:
* [`src/classes/private/Scope.ps1`](diffhunk://#diff-9f8b649c9594a7c7582dae3baf1841e8ffa82e1cbb7e1fae8b560b56f141e6f1R1-R4): Added a new `Scope` enum with `CurrentUser` and `AllUsers` values.

### Parameter Attribute Modifications:
* [`src/functions/public/Get-Font.ps1`](diffhunk://#diff-ee20084ba781ca437e01d19ac7f613301852186eaaac3f2a2c56227290631228L47-R47): Modified the `Scope` parameter to remove `ValueFromPipeline` attribute.
* [`src/functions/public/Install-Font.ps1`](diffhunk://#diff-d3add77d9955c82ca6cb9e9614242dfd502f6692662994dcb98d6a58b923abbfL72-R72): Modified the `Scope` parameter to remove `ValueFromPipeline` attribute.
* [`src/functions/public/Uninstall-Font.ps1`](diffhunk://#diff-2bda15615bb104b972c42d08b28af0a1692cbb5ec229ae212fc5959feab71f49L27-R40): Reordered and modified the `Scope` parameter to remove `ValueFromPipeline` attribute and added it after the `Name` parameter.

### Minor Code Improvements:
* [`src/functions/public/Install-Font.ps1`](diffhunk://#diff-d3add77d9955c82ca6cb9e9614242dfd502f6692662994dcb98d6a58b923abbfL211-R208): Changed double quotes to single quotes in a Write-Verbose message.
* [`src/functions/public/Uninstall-Font.ps1`](diffhunk://#diff-2bda15615bb104b972c42d08b28af0a1692cbb5ec229ae212fc5959feab71f49L62-L63): Removed an unnecessary line of code in the process block.

### Code Cleanup:
* [`src/header.ps1`](diffhunk://#diff-bf5fadbc74186e4ef45ea67f13aa39ff1aa054d079df0853f7c2c7180b486f71L1): Removed an outdated `using module` statement.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
