### PR TITLE
🩹 [Patch]: Bump `Admin` to 1.1.6

### DIFF
--- a/src/functions/public/Get-Font.ps1
+++ b/src/functions/public/Get-Font.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Admin'; RequiredVersion = '1.1.5' }
+﻿#Requires -Modules @{ ModuleName = 'Admin'; RequiredVersion = '1.1.6' }
 
 function Get-Font {
     <#

--- a/src/functions/public/Install-Font.ps1
+++ b/src/functions/public/Install-Font.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Admin'; RequiredVersion = '1.1.5' }
+﻿#Requires -Modules @{ ModuleName = 'Admin'; RequiredVersion = '1.1.6' }
 
 function Install-Font {
     <#


### PR DESCRIPTION
## Description

This pull request updates the required version of the `Admin` module in two PowerShell scripts to ensure compatibility with the latest features or fixes.

- Fixes #43 

Version updates:

* [`src/functions/public/Get-Font.ps1`](diffhunk://#diff-ee20084ba781ca437e01d19ac7f613301852186eaaac3f2a2c56227290631228L1-R1): Updated the `#Requires` directive to require `Admin` module version `1.1.6` instead of `1.1.5`.
* [`src/functions/public/Install-Font.ps1`](diffhunk://#diff-d3add77d9955c82ca6cb9e9614242dfd502f6692662994dcb98d6a58b923abbfL1-R1): Updated the `#Requires` directive to require `Admin` module version `1.1.6` instead of `1.1.5`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
